### PR TITLE
Fix affinity

### DIFF
--- a/server/game/CostReducer.ts
+++ b/server/game/CostReducer.ts
@@ -1,4 +1,4 @@
-import type { AbilityContext } from './AbilityContext.js';
+import { AbilityContext } from './AbilityContext.js';
 import type { AbilityLimit } from './AbilityLimit.js';
 import type BaseCard from './BaseCard.js';
 import type DrawCard from './DrawCard.js';
@@ -53,7 +53,7 @@ export class CostReducer {
         } else if(this.playingTypes && !this.playingTypes.includes(playingType)) {
             return false;
         }
-        const context = this.game.getFrameworkContext(card.controller);
+        const context = new AbilityContext({ game: this.game, player: card.controller, source: card });
         return this.checkMatch(card) && this.checkTargetCondition(context, target);
     }
 

--- a/server/game/Effects/Restriction.ts
+++ b/server/game/Effects/Restriction.ts
@@ -144,7 +144,6 @@ const checkRestrictions: Record<string, RestrictionCheck> = {
     },
     loseHonorAsCost: (context) => context.stage === Stage.Cost,
     unopposedHonorLoss: (context) => context.source.name === 'Framework effect',
-    // Darbuka of Banishment restricts Spells only, so anything else keeps its affinity.
     unlessMeishodo: (context) =>
         !!context.source && context.source.hasTrait('spell') && !context.source.hasTrait('meishodo')
 };

--- a/server/game/Effects/Restriction.ts
+++ b/server/game/Effects/Restriction.ts
@@ -144,10 +144,9 @@ const checkRestrictions: Record<string, RestrictionCheck> = {
     },
     loseHonorAsCost: (context) => context.stage === Stage.Cost,
     unopposedHonorLoss: (context) => context.source.name === 'Framework effect',
-    unlessMeishodo: (context) => {
-        const spell = context.source || context;
-        return !spell.hasTrait('meishodo');
-    }
+    // Darbuka of Banishment restricts Spells only, so anything else keeps its affinity.
+    unlessMeishodo: (context) =>
+        !!context.source && context.source.hasTrait('spell') && !context.source.hasTrait('meishodo')
 };
 
 const getApplyingPlayer = (effect: Restriction): Player => {

--- a/server/game/cards/01-Core/GraspOfEarth.ts
+++ b/server/game/cards/01-Core/GraspOfEarth.ts
@@ -14,7 +14,7 @@ export default class GraspOfEarth extends DrawCard {
         this.persistentEffect({
             location: Location.Any,
             targetController: Players.Any,
-            condition: (context) => context.player.hasAffinity('earth'),
+            condition: (context) => context.player.hasAffinity('earth', context),
             effect: AbilityDsl.effects.reduceCost({ amount: 1, match: (card, source) => card === source })
         });
 

--- a/server/game/cards/20-Core2/Phoenix/DrawingTheVoid.ts
+++ b/server/game/cards/20-Core2/Phoenix/DrawingTheVoid.ts
@@ -31,7 +31,7 @@ export default class DrawingTheVoid extends DrawCard {
                             gameAction: AbilityDsl.actions.moveCard({ destination: Location.RemovedFromGame })
                         })),
                         AbilityDsl.actions.conditional((context) => ({
-                            condition: context.player.hasAffinity('void'),
+                            condition: context.player.hasAffinity('void', context),
                             trueGameAction: AbilityDsl.actions.draw(),
                             falseGameAction: AbilityDsl.actions.noAction()
                         }))

--- a/server/game/cards/22-SoD/Crane/CastleOfAir.ts
+++ b/server/game/cards/22-SoD/Crane/CastleOfAir.ts
@@ -28,7 +28,7 @@ export default class CastleOfAir extends DrawCard {
                 cardCondition: (card: BaseCard) => card.hasTrait('shugenja')
             }),
             effect: 'increase the strength of an attacked province by 4{1}',
-            effectArgs: context => context.player.hasAffinity('air') ? [' and prevent unopposed honor loss'] : [''],
+            effectArgs: context => context.player.hasAffinity('air', context) ? [' and prevent unopposed honor loss'] : [''],
             condition: (context) => context.game.isDuringConflict(),
             gameAction: AbilityDsl.actions.multiple([
                 AbilityDsl.actions.selectCard((context) => ({
@@ -45,7 +45,7 @@ export default class CastleOfAir extends DrawCard {
                     })
                 })),
                 AbilityDsl.actions.conditional((context) => ({
-                    condition: context.player.hasAffinity('air'),
+                    condition: context.player.hasAffinity('air', context),
                     trueGameAction: AbilityDsl.actions.handler({
                         handler: context => {
                             this.playersTriggered.set(context.player.uuid, true);

--- a/server/game/cards/22-SoD/Phoenix/AppeasingTheRestless.ts
+++ b/server/game/cards/22-SoD/Phoenix/AppeasingTheRestless.ts
@@ -16,8 +16,8 @@ export default class AppeasingTheRestless extends DrawCard {
             }),
             cannotTargetFirst: true,
             effect: 'choose up to 3 spirits to place fate on{1}{2}',
-            effectArgs: context => context.player.hasAffinity('void') ? ['', ''] : [' and injure ', context.costs.bow as DrawCard],
-            condition: context => context.player.fate > 0 && context.player.checkRestrictions('spendFate', context) || !context.player.hasAffinity('void'),
+            effectArgs: context => context.player.hasAffinity('void', context) ? ['', ''] : [' and injure ', context.costs.bow as DrawCard],
+            condition: context => context.player.fate > 0 && context.player.checkRestrictions('spendFate', context) || !context.player.hasAffinity('void', context),
             gameAction: AbilityDsl.actions.multipleContext(context => {
                 const gameActions = [];
 
@@ -39,7 +39,7 @@ export default class AppeasingTheRestless extends DrawCard {
                     })));
                 }
 
-                if(!context.player.hasAffinity('void')) {
+                if(!context.player.hasAffinity('void', context)) {
                     gameActions.push(AbilityDsl.actions.conditional({
                         condition: () => (context.costs.bow?.getFate() ?? 0) === 0,
                         trueGameAction: AbilityDsl.actions.discardFromPlay({ target: context.costs.bow }),

--- a/server/game/cards/23-SN/Lion/AkodoTadakatsu.ts
+++ b/server/game/cards/23-SN/Lion/AkodoTadakatsu.ts
@@ -10,8 +10,14 @@ export default class AkodoTadakatsu extends DrawCard {
         this.reaction({
             title: 'Injure a character',
             when: {
-                onMoveFate: (event, context) => context.game.currentPhase !== Phases.Fate &&
-                    event.origin === context.source && event.fate > 0
+                onMoveFate: (event, context) => {
+                    if(context.game.currentPhase === Phases.Fate || event.origin !== context.source || event.fate <= 0) {
+                        return false;
+                    }
+                    const cause = event.context;
+                    return !!cause && !!context.player.opponent && cause.player === context.player.opponent &&
+                        ((cause.source.type as string) === 'ring' || cause.ability.isCardAbility());
+                }
             },
             target: {
                 controller: Players.Opponent,

--- a/server/game/cards/23-SN/Phoenix/JadePrison.ts
+++ b/server/game/cards/23-SN/Phoenix/JadePrison.ts
@@ -10,7 +10,7 @@ export default class JadePrison extends DrawCard {
         this.persistentEffect({
             location: Location.Any,
             targetController: Players.Any,
-            condition: (context) => context.player.hasAffinity('earth'),
+            condition: (context) => context.player.hasAffinity('earth', context),
             effect: AbilityDsl.effects.reduceCost({ amount: 1, match: (card, source) => card === source })
         });
 

--- a/server/game/cards/23-SN/Phoenix/LessonsFromEarth.ts
+++ b/server/game/cards/23-SN/Phoenix/LessonsFromEarth.ts
@@ -28,7 +28,7 @@ export default class LessonsFromEarth extends ProvinceAttachment {
                     target: winner
                 }));
 
-                const hasAffinity = loser.hasAffinity('earth');
+                const hasAffinity = loser.hasAffinity('earth', context);
                 if(!hasAffinity) {
                     gameActions.push(AbilityDsl.actions.chosenDiscard({
                         target: loser

--- a/server/game/cards/23-SN/Scorpion/APlagueOfYokai.ts
+++ b/server/game/cards/23-SN/Scorpion/APlagueOfYokai.ts
@@ -17,96 +17,38 @@ export default class APlagueOfYokai extends DrawCard {
 
         this.action({
             title: 'Spread the plague',
-            condition: context => {
-                if(!context.game.isDuringConflict()) {
-                    return false;
-                }
-                if(!context.player.anyCardsInPlay(card => card.isParticipating() && card.hasTrait('shinobi'))) {
-                    return false;
-                }
-                const { copiesInDeck, copiesInDiscard } = this.getCopies(context);
-                if(copiesInDiscard.length === 0 && copiesInDeck.length === 0) {
-                    return false;
-                }
-
-                return true;
-            },
+            condition: context => !!context.game.isDuringConflict() && this.getCopiesInDeck(context).length > 0,
+            cost: AbilityDsl.costs.dishonor({
+                controller: Players.Self,
+                cardType: CardType.Character,
+                cardCondition: card => card.isParticipating() && card.hasTrait('shinobi')
+            }),
             target: {
                 controller: Players.Any,
                 cardType: CardType.Character,
-                cardCondition: (card, context) => {
-                    const { copiesInDeck, copiesInDiscard } = this.getCopies(context);
-                    let attachment;
-                    if(copiesInDeck.length > 0) {
-                        attachment = copiesInDeck[0];
-                    } else if(copiesInDiscard.length > 0) {
-                        attachment = copiesInDiscard[0];
-                    }
-                    return card.isParticipating() && AbilityDsl.actions.attach().canAffect(card, context, { attachment });
-                },
-                gameAction: AbilityDsl.actions.multiple([
-                    AbilityDsl.actions.chooseAction((context) => {
-                        const { copiesInDeck, copiesInDiscard } = this.getCopies(context);
-
-                        let options = {};
-                        if(copiesInDiscard.length > 0) {
-                            const optionTitle = `Discard pile (${copiesInDiscard.length})`;
-                            options = {
-                                ...options,
-                                [optionTitle]: {
-                                    action: AbilityDsl.actions.attach({
-                                        target: context.target,
-                                        attachment: copiesInDiscard[0]
-                                    }),
-                                    message: '{0} takes from their discard pile'
-                                }
-                            };
-                        }
-                        if(copiesInDeck.length > 0) {
-                            const optionTitle = `Deck (${copiesInDeck.length})`;
-                            options = {
-                                ...options,
-                                [optionTitle]: {
-                                    action: AbilityDsl.actions.multiple([
-                                        AbilityDsl.actions.attach({
-                                            target: context.target,
-                                            attachment: copiesInDeck[0]
-                                        }),
-                                        AbilityDsl.actions.shuffleDeck({
-                                            deck: Location.ConflictDeck,
-                                            target: context.player
-                                        })
-                                    ]),
-                                    message: '{0} takes from their deck'
-                                }
-                            };
-                        }
-
-                        return {
-                            activePromptTitle: 'Select where to pull card from',
-                            options
-                        };
-                    }),
-                    AbilityDsl.actions.onAffinity(context => ({
-                        trait: 'shadow',
-                        gameAction: AbilityDsl.actions.noAction(),
-                        noAffinityGameAction: AbilityDsl.actions.loseHonor({
-                            target: context.player
+                cardCondition: (card, context) => !!context.player.opponent &&
+                    card.isParticipatingFor(context.player.opponent) &&
+                    AbilityDsl.actions.attach().canAffect(card, context, { attachment: this.getCopiesInDeck(context)[0] }),
+                gameAction: AbilityDsl.actions.multipleContext(context => ({
+                    gameActions: [
+                        AbilityDsl.actions.attach({
+                            target: context.target,
+                            attachment: this.getCopiesInDeck(context)[0]
                         }),
-                        effect: 'prevent the honor loss'
-                    }))
-                ])
+                        AbilityDsl.actions.shuffleDeck({
+                            deck: Location.ConflictDeck,
+                            target: context.player
+                        })
+                    ]
+                }))
             },
-            effect: 'infect {0} and lose 1 honor'
+            effect: 'infect {0}'
         });
     }
 
-    getCopies(context: AbilityContext) {
+    getCopiesInDeck(context: AbilityContext) {
         const player = context.player as Player;
-        const copiesInDiscard = player.conflictDiscardPile.filter(card => card.name === context.source.name);
-        const copiesInDeck = player.conflictDeck.filter(card => card.name === context.source.name);
-
-        return { copiesInDiscard, copiesInDeck };
+        return player.conflictDeck.filter(card => card.name === context.source.name);
     }
 
     getSkillModifier(context: AbilityContext) {

--- a/server/game/cards/23-SN/Unicorn/PathsNotTaken.ts
+++ b/server/game/cards/23-SN/Unicorn/PathsNotTaken.ts
@@ -7,14 +7,18 @@ export default class PathsNotTaken extends DrawCard {
     static id = 'paths-not-taken';
 
     setupCardAbilities() {
-        this.action({
+        this.reaction({
             title: 'Send home a character',
             max: AbilityDsl.limit.perConflict(1),
-            condition: context => !!context.game.isDuringConflict() && context.player.isDefendingPlayer(),
+            when: {
+                onConflictStarted: (event, context) => event.conflict.defendingPlayer === context.player
+            },
             target: {
                 cardType: CardType.Character,
                 controller: Players.Opponent,
-                cardCondition: (card, context) => card.isParticipating() && card.printedCost !== null && card.printedCost < this.getSkillThreshold(context),
+                cardCondition: (card, context) => !!context.player.opponent &&
+                    card.isParticipatingFor(context.player.opponent) &&
+                    card.printedCost !== null && card.printedCost < this.getSkillThreshold(context),
                 gameAction: AbilityDsl.actions.sendHome()
             }
         });

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -12,11 +12,13 @@ import type Player from '../game/Player.js';
 import { logger } from '../logger.js';
 import Socket from '../Socket.js';
 import { detectBinary } from '../util.js';
-import { WsSocket } from './WsSocket.js';
+import { stringifyWithoutCycles, WsSocket } from './WsSocket.js';
 import type { GameSummary, PendingGameDTO, ShortCardData, UserIdentity } from './LobbyProtocol.js';
 import type { GameDetails } from '../game/Game.js';
 import type { MenuItem } from '../game/MenuCommands.js';
 import * as env from '../env.js';
+
+const MAX_DEBUG_DATA_LENGTH = 4 * 1024 * 1024;
 
 export class GameServer implements GameRouter {
     private games = new Map<string, Game>();
@@ -120,24 +122,13 @@ export class GameServer implements GameRouter {
     handleError(game: Game, e: Error) {
         logger.error(`Game error: ${e.message}\n${e.stack}`);
 
-        let gameState = game.getState();
-        let debugData: Record<string, unknown> = {};
+        const debugData: Record<string, unknown> = {};
 
         if(e.message.includes('Maximum call stack')) {
-            debugData.badSerializaton = detectBinary(gameState);
+            debugData.badSerializaton = detectBinary(game.getState());
         } else {
-            debugData.game = gameState;
-            (debugData.game as Record<string, unknown>).players = undefined;
-
-            debugData.messages = game.messages;
-            (debugData.game as Record<string, unknown>).messages = undefined;
-
             debugData.pipeline = game.pipeline.getDebugInfo();
             debugData.effectEngine = game.effectEngine.getDebugInfo();
-
-            for(const player of game.getPlayers()) {
-                debugData[player.name] = player.getState(player);
-            }
         }
 
         const playerNames = game.getPlayers().map((p) => p.name);
@@ -149,7 +140,7 @@ export class GameServer implements GameRouter {
                 errorMessage: e.message,
                 errorStack: e.stack,
                 timestamp: new Date().toISOString(),
-                debugData: debugData
+                debugData: this.limitDebugData(debugData)
             });
         }
 
@@ -157,6 +148,20 @@ export class GameServer implements GameRouter {
             game.addMessage(
                 'A Server error has occured processing your game state, apologies.  Your game may now be in an inconsistent state, or you may be able to continue.  The error has been logged.'
             );
+        }
+    }
+
+    // The report has to survive a WebSocket frame and then a Mongo document, so keep
+    // the message and stack at any cost and drop the debug data if it will not fit.
+    private limitDebugData(debugData: Record<string, unknown>): unknown {
+        try {
+            const length = stringifyWithoutCycles(debugData).length;
+            if(length <= MAX_DEBUG_DATA_LENGTH) {
+                return debugData;
+            }
+            return { omitted: `${length} characters, over the ${MAX_DEBUG_DATA_LENGTH} limit` };
+        } catch(err) {
+            return { omitted: `could not be serialized: ${err}` };
         }
     }
 

--- a/server/gamenode/WsSocket.ts
+++ b/server/gamenode/WsSocket.ts
@@ -19,7 +19,7 @@ const MAX_RECONNECT_DELAY = 5_000;
 
 // Error payloads carry game debug data, which can contain references back to the
 // Game object. Replace cycles instead of throwing so the report still gets sent.
-function stringifyWithoutCycles(value: unknown): string {
+export function stringifyWithoutCycles(value: unknown): string {
     const ancestors: unknown[] = [];
 
     return JSON.stringify(value, function(this: unknown, _key: string, val: unknown) {

--- a/test/server/GameServer.spec.ts
+++ b/test/server/GameServer.spec.ts
@@ -24,6 +24,8 @@ type GameSpy = jasmine.SpyObj<{
     password?: string;
     playersAndSpectators: Record<string, unknown>;
     gameChat: { messages: unknown[] };
+    pipeline: { getDebugInfo: () => unknown };
+    effectEngine: { getDebugInfo: () => unknown };
 };
 
 type ServerCtx = {
@@ -267,6 +269,59 @@ describe('GameServer.notifyAndCloseGame', () => {
         call('notifyAndCloseGame', ctx, game);
         expect(playerSocketSpy.send).not.toHaveBeenCalled();
         expect(ctx.wsSocket.send).toHaveBeenCalledWith('GAMECLOSED', { game: 'g1' });
+    });
+});
+
+describe('GameServer.handleError', () => {
+    function makeErroringGame(pipelineInfo: unknown) {
+        const game = makeGame();
+        game.getPlayers.and.returnValue([{ name: 'p1' }, { name: 'p2' }]);
+        game.pipeline = { getDebugInfo: () => pipelineInfo };
+        game.effectEngine = { getDebugInfo: () => ({ effects: [] }) };
+        return game;
+    }
+
+    function sentPayload(ctx: ServerCtx) {
+        const args = ctx.wsSocket.send.calls.mostRecent().args;
+        return { command: args[0], arg: args[1] as Record<string, unknown> };
+    }
+
+    it('sends the debug data when it is small enough', () => {
+        const ctx = makeCtx();
+        const game = makeErroringGame({ step: 'ConflictFlow' });
+
+        call('handleError', ctx, game, new Error('boom'));
+
+        const { command, arg } = sentPayload(ctx);
+        expect(command).toBe('GAMEERROR');
+        expect(arg.errorMessage).toBe('boom');
+        expect(arg.debugData).toEqual({ pipeline: { step: 'ConflictFlow' }, effectEngine: { effects: [] } });
+    });
+
+    it('drops oversized debug data but still reports the error', () => {
+        const ctx = makeCtx();
+        const game = makeErroringGame({ blob: 'x'.repeat(5 * 1024 * 1024) });
+
+        call('handleError', ctx, game, new Error('boom'));
+
+        const { command, arg } = sentPayload(ctx);
+        expect(command).toBe('GAMEERROR');
+        expect(arg.errorMessage).toBe('boom');
+        expect(arg.errorStack).toBeDefined();
+        expect((arg.debugData as { omitted?: string }).omitted).toContain('over the');
+    });
+
+    it('drops debug data that cannot be serialized at all', () => {
+        const ctx = makeCtx();
+        const game = makeErroringGame({ get boom() {
+            throw new Error('nope');
+        } });
+
+        call('handleError', ctx, game, new Error('boom'));
+
+        const { arg } = sentPayload(ctx);
+        expect(arg.errorMessage).toBe('boom');
+        expect((arg.debugData as { omitted?: string }).omitted).toContain('could not be serialized');
     });
 });
 

--- a/test/server/cards/20-Core2/Unicorn/DarbukaOfBanishment.spec.js
+++ b/test/server/cards/20-Core2/Unicorn/DarbukaOfBanishment.spec.js
@@ -39,7 +39,7 @@ describe('Darbuka of Banishment', function () {
                 expect(this.player1).not.toHavePrompt('Discard all cards from a province?');
             });
 
-            it('leaves a Meishodo spell its affinity', function () {
+            it('does not remove affinity from Meishodo spells', function () {
                 this.player1.clickCard(this.rushingWave);
                 this.player1.clickCard(this.shamefulDisplay);
 

--- a/test/server/cards/20-Core2/Unicorn/DarbukaOfBanishment.spec.js
+++ b/test/server/cards/20-Core2/Unicorn/DarbukaOfBanishment.spec.js
@@ -6,7 +6,8 @@ describe('Darbuka of Banishment', function () {
                     phase: 'conflict',
                     player1: {
                         inPlay: ['miya-mystic', 'adept-of-the-waves'],
-                        hand: ['rejuvenating-vapors', 'grasp-of-earth-2']
+                        hand: ['rejuvenating-vapors', 'grasp-of-earth-2', 'the-rushing-wave'],
+                        role: 'keeper-of-water'
                     },
                     player2: {
                         inPlay: ['moto-youth'],
@@ -17,6 +18,7 @@ describe('Darbuka of Banishment', function () {
 
                 this.suitengu = this.player1.findCardByName('rejuvenating-vapors');
                 this.graspOfEarth = this.player1.findCardByName('grasp-of-earth-2');
+                this.rushingWave = this.player1.findCardByName('the-rushing-wave');
                 this.mystic = this.player1.findCardByName('miya-mystic');
                 this.mystic.bow();
 
@@ -35,6 +37,15 @@ describe('Darbuka of Banishment', function () {
                 this.player1.clickCard(this.mystic);
                 expect(this.getChatLogs(5)).toContain('player1 plays Rejuvenating Vapors to ready Miya Mystic');
                 expect(this.player1).not.toHavePrompt('Discard all cards from a province?');
+            });
+
+            it('leaves a Meishodo spell its affinity', function () {
+                this.player1.clickCard(this.rushingWave);
+                this.player1.clickCard(this.shamefulDisplay);
+
+                // Meishodo is exempt, so the neighbouring provinces drop as well.
+                expect(this.shamefulDisplay.getStrength()).toBe(0);
+                expect(this.player2.findCardByName('shameful-display', 'province 2').getStrength()).toBe(0);
             });
 
             it('removes affinity from spell attachments', function () {

--- a/test/server/cards/23-SN/Crane/IllusionaryTerrain.spec.js
+++ b/test/server/cards/23-SN/Crane/IllusionaryTerrain.spec.js
@@ -13,7 +13,7 @@ describe('Illusionary Terrain', function () {
                     inPlay: ['brash-samurai'],
                     provinces: ['the-pursuit-of-justice', 'fertile-fields', 'avalanche-of-stone', 'elemental-fury'],
                     hand: ['illusionary-terrain'],
-                    dynastyDiscard: ['doomed-shugenja', 'asahina-augur'],
+                    dynastyDiscard: ['doomed-shugenja', 'asahina-purifier'],
                     role: 'keeper-of-void'
                 }
             });
@@ -32,7 +32,7 @@ describe('Illusionary Terrain', function () {
             this.scout = this.player1.findCardByName('eager-scout');
             this.brash = this.player2.findCardByName('brash-samurai');
             this.doomed = this.player2.findCardByName('doomed-shugenja');
-            this.augur = this.player2.findCardByName('asahina-augur');
+            this.purifier = this.player2.findCardByName('asahina-purifier');
 
             this.terrain = this.player2.findCardByName('illusionary-terrain');
 
@@ -94,7 +94,7 @@ describe('Illusionary Terrain', function () {
         });
 
         it('targeting - affinity', function () {
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.noMoreActions();
             this.initiateConflict({
                 attackers: [this.toshimoko],
@@ -116,7 +116,7 @@ describe('Illusionary Terrain', function () {
         });
 
         it('copy - passive effect', function () {
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.noMoreActions();
             this.initiateConflict({
                 attackers: [this.toshimoko],
@@ -138,7 +138,7 @@ describe('Illusionary Terrain', function () {
 
         it('copy onto a facedown province', function () {
             this.fury.facedown = true;
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.noMoreActions();
             this.initiateConflict({
                 attackers: [this.toshimoko],
@@ -159,7 +159,7 @@ describe('Illusionary Terrain', function () {
         });
 
         it('copy - action ability', function () {
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.noMoreActions();
             this.initiateConflict({
                 attackers: [this.toshimoko],
@@ -184,7 +184,7 @@ describe('Illusionary Terrain', function () {
         });
 
         it('copy - reaction ability', function () {
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.noMoreActions();
             this.initiateConflict({
                 attackers: [this.toshimoko],
@@ -208,7 +208,7 @@ describe('Illusionary Terrain', function () {
 
         it('copy - on reveal', function () {
             this.fury.facedown = true;
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.noMoreActions();
             this.initiateConflict({
                 attackers: [this.toshimoko],
@@ -225,13 +225,13 @@ describe('Illusionary Terrain', function () {
             expect(this.getChatLogs(10)).toContain('player2 plays Illusionary Terrain to transform the attacked province into a copy of Avalanche of Stone');
             expect(this.player2).toBeAbleToSelect(this.fury);
             this.player2.clickCard(this.fury);
-            expect(this.augur.bowed).toBe(true);
-            expect(this.getChatLogs(10)).toContain('player2 uses Avalanche of Stone\'s gained ability from Avalanche of Stone to bow Eager Scout, Brash Samurai and Asahina Augur');
+            expect(this.purifier.bowed).toBe(true);
+            expect(this.getChatLogs(10)).toContain('player2 uses Avalanche of Stone\'s gained ability from Avalanche of Stone to bow Eager Scout, Brash Samurai and Asahina Purifier');
         });
 
         it('copy - interrupt', function () {
             this.fury.facedown = true;
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.scout.dishonor();
             this.noMoreActions();
             this.initiateConflict({
@@ -276,7 +276,7 @@ describe('Illusionary Terrain', function () {
         });
 
         it('discount 1', function () {
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             let fate = this.player2.fate;
             this.noMoreActions();
             this.initiateConflict({
@@ -295,7 +295,7 @@ describe('Illusionary Terrain', function () {
         });
 
         it('discount 2', function () {
-            this.player2.moveCard(this.augur, 'play area');
+            this.player2.moveCard(this.purifier, 'play area');
             this.player2.moveCard(this.doomed, 'play area');
             let fate = this.player2.fate;
             this.noMoreActions();

--- a/test/server/cards/23-SN/Lion/AkodoTakakatsu.spec.js
+++ b/test/server/cards/23-SN/Lion/AkodoTakakatsu.spec.js
@@ -8,7 +8,8 @@ describe('Akodo Takakatsu', function () {
                     hand: ['invocation-of-ash']
                 },
                 player2: {
-                    inPlay: ['togashi-mitsu', 'doji-whisperer']
+                    inPlay: ['togashi-mitsu', 'doji-whisperer'],
+                    hand: ['mono-no-aware']
                 }
             });
             this.mitsu = this.player2.findCardByName('togashi-mitsu');
@@ -17,16 +18,16 @@ describe('Akodo Takakatsu', function () {
             this.tadakatsu = this.player1.findCardByName('akodo-tadakatsu');
             this.challenger = this.player1.findCardByName('doji-challenger');
             this.invocation = this.player1.findCardByName('invocation-of-ash');
+            this.monoNoAware = this.player2.findCardByName('mono-no-aware');
 
             this.tadakatsu.fate = 2;
             this.mitsu.fate = 1;
         });
 
-        it('reaction to removing fate', function () {
-            this.player1.playAttachment(this.invocation, this.challenger);
-            this.player2.pass();
-            this.player1.clickCard(this.invocation);
-            this.player1.clickCard(this.tadakatsu);
+        it('reaction to an opponent removing fate', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.monoNoAware);
+            expect(this.tadakatsu.fate).toBe(1);
             expect(this.player1).toHavePrompt('Triggered Abilities');
             expect(this.player1).toBeAbleToSelect(this.tadakatsu);
 
@@ -39,6 +40,38 @@ describe('Akodo Takakatsu', function () {
             this.player1.clickCard(this.whisperer);
             expect(this.whisperer.location).toBe('dynasty discard pile');
             expect(this.getChatLogs(5)).toContain('player1 uses Akodo Tadakatsu to injure Doji Whisperer');
+        });
+
+        it('reaction to an opponent resolving a ring effect', function () {
+            this.noMoreActions();
+            this.player1.passConflict();
+            this.noMoreActions();
+            this.initiateConflict({
+                ring: 'void',
+                type: 'political',
+                attackers: [this.whisperer],
+                defenders: []
+            });
+            this.noMoreActions();
+
+            this.player2.clickCard(this.tadakatsu);
+            expect(this.tadakatsu.fate).toBe(1);
+
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            this.player1.clickCard(this.tadakatsu);
+            this.player1.clickCard(this.mitsu);
+            expect(this.mitsu.fate).toBe(0);
+        });
+
+        it('no reaction when your own card removes the fate', function () {
+            this.player1.playAttachment(this.invocation, this.challenger);
+            this.player2.pass();
+            this.player1.clickCard(this.invocation);
+            this.player1.clickCard(this.tadakatsu);
+
+            expect(this.tadakatsu.fate).toBe(1);
+            expect(this.player1).not.toBeAbleToSelect(this.tadakatsu);
+            expect(this.player1).toHavePrompt('Waiting for opponent to take an action or pass');
         });
 
         it('reaction to attacking - bow', function () {

--- a/test/server/cards/23-SN/Lion/AkodoTakakatsu.spec.js
+++ b/test/server/cards/23-SN/Lion/AkodoTakakatsu.spec.js
@@ -54,6 +54,7 @@ describe('Akodo Takakatsu', function () {
             });
             this.noMoreActions();
 
+            this.player2.clickPrompt('No');
             this.player2.clickCard(this.tadakatsu);
             expect(this.tadakatsu.fate).toBe(1);
 

--- a/test/server/cards/23-SN/Scorpion/APlagueOfYokai.spec.js
+++ b/test/server/cards/23-SN/Scorpion/APlagueOfYokai.spec.js
@@ -1,4 +1,4 @@
-﻿import { GameModes } from '../../../../../build/server/GameModes.js';
+import { GameModes } from '../../../../../build/server/GameModes.js';
 
 describe('A Plague of Yokai', function () {
     integration(function () {
@@ -50,20 +50,24 @@ describe('A Plague of Yokai', function () {
             expect(this.challenger.getMilitarySkill()).toBe(2);
             expect(this.challenger.getPoliticalSkill()).toBe(2);
 
+            let length = this.player1.conflictDeck.length;
+
             this.player1.clickCard(this.plague1);
-            expect(this.player1).toBeAbleToSelect(this.shadows);
+
+            // Only characters on the enemy side can be infected.
+            expect(this.player1).not.toBeAbleToSelect(this.shadows);
             expect(this.player1).not.toBeAbleToSelect(this.challenger);
             expect(this.player1).toBeAbleToSelect(this.kuwanan);
             expect(this.player1).toBeAbleToSelect(this.yoshi);
-
             this.player1.clickCard(this.yoshi);
-            expect(this.player1).toHavePrompt('Select where to pull card from');
-            expect(this.player1).toHavePromptButton('Discard pile (1)');
-            expect(this.player1).toHavePromptButton('Deck (1)');
 
-            let length = this.player1.conflictDeck.length;
-
-            this.player1.clickPrompt('Deck (1)');
+            // The dishonor is a cost, and only a friendly participating Shinobi pays it.
+            expect(this.player1).toHavePrompt('Select character to dishonor');
+            expect(this.player1).toBeAbleToSelect(this.shadows);
+            expect(this.player1).not.toBeAbleToSelect(this.serpent);
+            expect(this.player1).not.toBeAbleToSelect(this.kuwanan);
+            this.player1.clickCard(this.shadows);
+            expect(this.shadows.isDishonored).toBe(true);
 
             expect(this.plague2.parent).toBe(this.yoshi);
             expect(this.challenger.getMilitarySkill()).toBe(1);
@@ -73,63 +77,49 @@ describe('A Plague of Yokai', function () {
 
             expect(this.player1.conflictDeck.length).toBe(length - 1);
 
-            expect(this.getChatLogs(10)).toContain('player1 uses A Plague of Yokai to infect Kakita Yoshi and lose 1 honor');
-            expect(this.getChatLogs(10)).toContain('player1 takes from their deck');
-            expect(this.getChatLogs(10)).toContain('player1 channels their shadow affinity to prevent the honor loss');
+            expect(this.getChatLogs(10)).toContain('player1 uses A Plague of Yokai, dishonoring Adept of Shadows to infect Kakita Yoshi');
             expect(this.getChatLogs(10)).toContain('player1 is shuffling their conflict deck');
-
-            this.player2.pass();
-
-            this.player1.clickCard(this.plague2);
-            expect(this.player1).toBeAbleToSelect(this.shadows);
-            expect(this.player1).not.toBeAbleToSelect(this.challenger);
-            expect(this.player1).toBeAbleToSelect(this.kuwanan);
-            expect(this.player1).not.toBeAbleToSelect(this.yoshi);
-
-            this.player1.clickCard(this.kuwanan);
-            expect(this.player1).toHavePrompt('Select where to pull card from');
-            expect(this.player1).toHavePromptButton('Discard pile (1)');
-            expect(this.player1).not.toHavePromptButton('Deck (1)');
-
-            let length2 = this.player1.conflictDiscard.length;
-
-            this.player1.clickPrompt('Discard pile (1)');
-
-            expect(this.plague3.parent).toBe(this.kuwanan);
-            expect(this.challenger.getMilitarySkill()).toBe(0);
-            expect(this.challenger.getPoliticalSkill()).toBe(0);
-            expect(this.yoshi.getMilitarySkill()).toBe(0);
-            expect(this.yoshi.getPoliticalSkill()).toBe(3);
-            expect(this.kuwanan.getMilitarySkill()).toBe(2);
-            expect(this.kuwanan.getPoliticalSkill()).toBe(1);
-
-            expect(this.player1.conflictDiscard.length).toBe(length2 - 1);
-
-            expect(this.getChatLogs(10)).toContain('player1 uses A Plague of Yokai to infect Doji Kuwanan and lose 1 honor');
-            expect(this.getChatLogs(10)).toContain('player1 takes from their discard pile');
-            expect(this.getChatLogs(10)).toContain('player1 channels their shadow affinity to prevent the honor loss');
         });
 
-        it('no affinity', function () {
-            this.player1.moveCard(this.serpent, 'dynasty discard pile');
+        it('does not search the discard pile', function () {
+            this.player1.moveCard(this.plague2, 'conflict discard pile');
+
             this.noMoreActions();
             this.initiateConflict({
                 attackers: [this.shadows],
-                defenders: [this.challenger, this.kuwanan, this.yoshi]
+                defenders: [this.challenger]
             });
-            let honor = this.player1.honor;
             this.player2.pass();
+
             this.player1.clickCard(this.plague1);
             this.player1.clickCard(this.challenger);
+            expect(this.plague1.parent).toBe(this.challenger);
+
+            this.player2.pass();
+
+            // Only copies in the conflict deck can be found.
+            this.player1.clickCard(this.plague1);
+            expect(this.player1).not.toBeAbleToSelect(this.challenger);
+            expect(this.plague2.location).toBe('conflict discard pile');
+        });
+
+        it('cannot be used without a friendly participating Shinobi', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.serpent],
+                defenders: [this.challenger]
+            });
+            this.player2.pass();
+
+            this.player1.clickCard(this.plague1);
+            this.player1.clickCard(this.challenger);
+            expect(this.plague1.parent).toBe(this.challenger);
 
             this.player2.pass();
 
             this.player1.clickCard(this.plague1);
-            this.player1.clickCard(this.yoshi);
-            this.player1.clickPrompt('Deck (1)');
-            expect(this.plague2.parent).toBe(this.yoshi);
-            expect(this.player1.honor).toBe(honor - 1);
-            expect(this.getChatLogs(10)).not.toContain('player1 channels their shadow affinity to prevent the honor loss');
+            expect(this.player1).not.toBeAbleToSelect(this.challenger);
+            expect(this.plague2.location).toBe('conflict deck');
         });
     });
 });

--- a/test/server/cards/23-SN/Unicorn/PathsNotTaken.spec.js
+++ b/test/server/cards/23-SN/Unicorn/PathsNotTaken.spec.js
@@ -5,7 +5,10 @@ describe('Paths Not Taken', function () {
                 phase: 'conflict',
                 player1: {
                     inPlay: ['cautious-scout', 'doji-challenger', 'aranat'],
-                    hand: ['paths-not-taken', 'desperate-defense']
+                    // Entrenched Position is printed 5 and 10 during a military conflict,
+                    // so printed and total strength pick out different characters.
+                    provinces: ['entrenched-position'],
+                    hand: ['paths-not-taken']
                 },
                 player2: {
                     inPlay: ['togashi-mitsu-2', 'doji-whisperer', 'miya-mystic']
@@ -19,7 +22,7 @@ describe('Paths Not Taken', function () {
             this.challenger = this.player1.findCardByName('doji-challenger');
             this.aranat = this.player1.findCardByName('aranat');
             this.paths = this.player1.findCardByName('paths-not-taken');
-            this.defense = this.player1.findCardByName('desperate-defense');
+            this.province = this.player1.findCardByName('entrenched-position');
         });
 
         it('no scout', function () {
@@ -27,12 +30,12 @@ describe('Paths Not Taken', function () {
             this.player1.passConflict();
             this.noMoreActions();
             this.initiateConflict({
+                province: this.province,
                 attackers: [this.mitsu, this.whisperer],
                 defenders: [this.challenger]
             });
-            this.player1.clickCard(this.defense);
-            this.player2.pass();
 
+            expect(this.player1).toHavePrompt('Triggered Abilities');
             this.player1.clickCard(this.paths);
             expect(this.player1).not.toBeAbleToSelect(this.mitsu);
             expect(this.player1).toBeAbleToSelect(this.whisperer);
@@ -40,6 +43,7 @@ describe('Paths Not Taken', function () {
 
             this.player1.clickCard(this.whisperer);
 
+            expect(this.whisperer.isParticipating()).toBe(false);
             expect(this.getChatLogs(5)).toContain('player1 plays Paths not Taken to send Doji Whisperer home');
         });
 
@@ -48,12 +52,12 @@ describe('Paths Not Taken', function () {
             this.player1.passConflict();
             this.noMoreActions();
             this.initiateConflict({
+                province: this.province,
                 attackers: [this.mitsu, this.whisperer],
                 defenders: [this.challenger, this.scout]
             });
-            this.player1.clickCard(this.defense);
-            this.player2.pass();
 
+            expect(this.player1).toHavePrompt('Triggered Abilities');
             this.player1.clickCard(this.paths);
             expect(this.player1).toBeAbleToSelect(this.mitsu);
             expect(this.player1).toBeAbleToSelect(this.whisperer);
@@ -62,7 +66,23 @@ describe('Paths Not Taken', function () {
 
             this.player1.clickCard(this.mitsu);
 
+            expect(this.mitsu.isParticipating()).toBe(false);
             expect(this.getChatLogs(5)).toContain('player1 plays Paths not Taken to send Togashi Mitsu home');
+        });
+
+        it('cannot be played while attacking', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.challenger],
+                defenders: [this.mitsu]
+            });
+
+            expect(this.player1).not.toHavePrompt('Triggered Abilities');
+
+            this.player2.pass();
+            this.player1.clickCard(this.paths);
+            expect(this.paths.location).toBe('hand');
+            expect(this.mitsu.isParticipating()).toBe(true);
         });
     });
 });


### PR DESCRIPTION
- fix potential crashes with missing context on affinity checks
- use proper context for cards
- Improve error logging to admin view
- Limit `unlessMeishodo` to spells